### PR TITLE
Pkg updates

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Build-Depends: debhelper (>= 9),
          devscripts,
          debconf (>= 0.2.26),
          ti-pru-cgt-installer,
+         pru-software-support-package,
 Standards-Version: 3.9.5
 Maintainer: James Strawson <james@strawsondesign.com>
 Homepage: <strawsondesign.com>

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,10 @@
 Source: roboticscape
 Section: utils
 Priority: optional
-Build-Depends: devscripts, debhelper (>= 9), debconf (>= 0.2.26)
+Build-Depends: debhelper (>= 9),
+         devscripts,
+         debconf (>= 0.2.26),
+         ti-pru-cgt-installer,
 Standards-Version: 3.9.5
 Maintainer: James Strawson <james@strawsondesign.com>
 Homepage: <strawsondesign.com>

--- a/pru_firmware/Makefile
+++ b/pru_firmware/Makefile
@@ -26,8 +26,8 @@ CLPRU=/usr/bin/clpru
 
 
 LINKER_COMMAND_FILE=./AM335x_PRU.cmd
-LIBS=--library=/opt/source/pru-software-support-package/lib/rpmsg_lib.lib
-INCLUDE=--include_path=/opt/source/pru-software-support-package/include --include_path=/opt/source/pru-software-support-package/include/am335x
+LIBS=--library=/usr/lib/ti/pru-software-support-package/lib/rpmsg_lib.lib
+INCLUDE=--include_path=/usr/lib/ti/pru-software-support-package/include --include_path=/usr/lib/ti/pru-software-support-package/include/am335x
 STACK_SIZE=0x100
 HEAP_SIZE=0x100
 


### PR DESCRIPTION
Getting closer to having this packaged:

```
   dh_auto_install
	make -j1 install DESTDIR=/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/debian/roboticscape AM_UPDATE_INFO_DIR=no
make[1]: Entering directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108'
make[2]: Entering directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/pru_firmware'
make[3]: Entering directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/pru_firmware'
Generated: bin/main-pru1-fw.out bin/main-pru0-fw.out
make[3]: Leaving directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/pru_firmware'
PRU Firmware Install Complete
make[2]: Leaving directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/pru_firmware'
make[2]: Entering directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/libraries'
make[3]: Entering directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/libraries'
make[3]: Leaving directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/libraries'
ldconfig: Can't create temporary cache file /etc/ld.so.cache~: Permission denied
Makefile:36: recipe for target 'install' failed
make[2]: *** [install] Error 1
make[2]: Leaving directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/libraries'
Makefile:17: recipe for target 'install' failed
make[1]: *** [install] Error 2
make[1]: Leaving directory '/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108'
dh_auto_install: make -j1 install DESTDIR=/home/voodoo/repos/strawsondesign-8-roboticscape/jessie/roboticscape_0.1.4-git20161108/debian/roboticscape AM_UPDATE_INFO_DIR=no returned exit code 2
debian/rules:3: recipe for target 'binary' failed
make: *** [binary] Error 2
dpkg-buildpackage: error: fakeroot debian/rules binary gave error exit status 2
debuild: fatal error at line 1376:
dpkg-buildpackage -rfakeroot -D -us -uc failed
```