### PR TITLE
Fixed DSM radio bug in rc_balance

### DIFF
--- a/examples/rc_balance/rc_balance.c
+++ b/examples/rc_balance/rc_balance.c
@@ -175,6 +175,11 @@ int main(){
 		rc_blink_led(RED, 5, 5);
 		return -1;
 	}
+
+	// set up DSM radio
+	if(rc_initialize_dsm()){
+		printf("ERROR: can't initialize DSM radio\n");
+	}
 	
 	// start balance stack to control setpoints
 	pthread_t  setpoint_thread;
@@ -372,7 +377,7 @@ void balance_controller(){
 	* gama (steering) controller D3
 	* move the setpoint gamma based on user input like phi
 	***********************************************************/
-	if(fabs(setpoint.gamma_dot>0.0001)) setpoint.gamma += setpoint.gamma_dot * DT;
+	if(fabs(setpoint.gamma_dot)>0.0001) setpoint.gamma += setpoint.gamma_dot * DT;
 	cstate.d3_u = rc_march_filter(&D3,setpoint.gamma - cstate.gamma);
 	
 	/**********************************************************


### PR DESCRIPTION
Added call to rc_initialize_dsm() to rc_balance to make DSM radio work. Tested on EduMiP with an OrangeRX satellite receiver.