### PR TITLE
Add setuid flag on install

### DIFF
--- a/examples/robotics.mk
+++ b/examples/robotics.mk
@@ -11,7 +11,7 @@ OBJECTS		:= $(SOURCES:$%.c=$%.o)
 
 prefix		:= /usr
 RM			:= rm -f
-INSTALL		:= install -m 755 
+INSTALL		:= install -m 4755 
 INSTALLDIR	:= install -d -m 755
 
 LINK		:= ln -s -f


### PR DESCRIPTION
This seems like a simple fix to users running as 'debian' to me. Is it security that keeps you from wanting to do this?