### PR TITLE
Add INCLUDES to build dependencies

### DIFF
--- a/examples/robotics.mk
+++ b/examples/robotics.mk
@@ -24,7 +24,7 @@ $(TARGET): $(OBJECTS)
 
 
 # compiling command
-$(OBJECTS): %.o : %.c
+$(OBJECTS): %.o : %.c $(INCLUDES)
 	@$(CC) $(CFLAGS) -c $< -o $(@)
 
 


### PR DESCRIPTION
This adds INCLUDES as a build depedency in robotics.mk. This way, if you
edit a header file and run `make` for an example, the example will rebuild.