### PR TITLE
Allow the use of the library w/out root, using capabilities instead

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,11 +6,13 @@ Build-Depends: debhelper (>= 9),
          debconf (>= 0.2.26),
          ti-pru-cgt-installer,
          pru-software-support-package,
+         libcap2-dev,
 Standards-Version: 3.9.5
 Maintainer: James Strawson <james@strawsondesign.com>
 Homepage: <www.strawsondesign.com>
 
 Package: roboticscape
 Architecture: armhf
+Depends: libcap2
 Description: Robotics Cape Library and Examples
 	Supporting library and example programs for the Robotics Cape and Beaglebone Blue

--- a/libraries/Makefile
+++ b/libraries/Makefile
@@ -10,7 +10,7 @@ ARCFLAGS	:= -mfpu=neon -mfloat-abi=hard -march=armv7-a -mtune=cortex-a8
 # enable O3 optimization and vectorized math
 FFLAGS		:= -O3 -ffast-math -ftree-vectorize
 CFLAGS		:= -c -fPIC
-LFLAGS		:= -lm -lrt -lpthread -shared -Wl,-soname,$(TARGET)
+LFLAGS		:= -lm -lrt -lpthread -lcap -shared -Wl,-soname,$(TARGET)
 
 SOURCES		:= $(shell find ./ -name '*.c')
 INCLUDES	:= $(shell find ./ -name '*.h')


### PR DESCRIPTION
Currently libroboticscape does not allow running rc_initialize unless user is root.

This PR will allow rc_initialize to succeed when user is not root but the process has the required capabilities.

As far as I was able to narrow those, 
the required capabilities are CAP_SYS_RAWIO and CAP_DAC_OVERRIDE.

Programers using the library might want to drop capabilities at some point.

To give the required capabilities to a binary you SHOULD use setcap.
```
   sudo apt-get install libcap2-bin          #install setcap et al
   sudo setcap cap_sys_rawio,cap_dac_override+epi /path/to/your/binary
```
This introduces a dependency with libcap2 on runtime.
This introduces a dependency with libcap-dev on build-time.