### PR TITLE
0.4.1 git20180424 systemd generic board fixes

### DIFF
--- a/services/rc_battery_monitor/src/rc_battery_monitor.c
+++ b/services/rc_battery_monitor/src/rc_battery_monitor.c
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
 	if(model!=BB_BLACK_RC && model!=BB_BLACK_W_RC && model!=BB_BLUE){
 		if(system("grep -q roboticscape /boot/uEnv.txt")!=0){
 			fprintf(stderr,"rc_battery_monitor can only run on BB Blue, Black, and Black wireless when the roboticscape device tree is in use.\n");
-			return -1;
+			return 0;
 		}
 	}
 

--- a/services/roboticscape/roboticscape.service
+++ b/services/roboticscape/roboticscape.service
@@ -6,7 +6,7 @@ Requires=systemd-modules-load.service
 User=root
 PIDFile=/var/run/roboticscape/roboticscape.pid
 ExecStartPre=/usr/bin/rc_startup_routine
-ExecStart=/etc/roboticscape/link_to_startup_program
+ExecStart=-/etc/roboticscape/link_to_startup_program
 ExecStop=/usr/bin/rc_kill
 
 [Install]

--- a/services/roboticscape/src/rc_startup_routine.c
+++ b/services/roboticscape/src/rc_startup_routine.c
@@ -56,7 +56,7 @@ int main()
 	if(model!=BB_BLACK_RC && model!=BB_BLACK_W_RC && model!=BB_BLUE){
 		if(system("grep -q roboticscape /boot/uEnv.txt")!=0){
 			fprintf(stderr,"roboticscape service can only run on BB Blue, Black, and Black wireless when the roboticscape device tree is in use.\n");
-			return -1;
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
@StrawsonDesign these 3 patches fix a few systemd issues when a non-"roboticape" board is loaded:

Before:
```
rootfs: clean, 82122/959616 files, 498914/3888512 blocks
[FAILED] Failed to start roboticscape.
See 'systemctl status roboticscape.service' for details.
[  OK  ] Started LSB: Start busybox udhcpd at boot time.

debian@beaglebone:~$ systemctl status
● beaglebone
    State: degraded
     Jobs: 0 queued
   Failed: 2 units
    Since: Tue 2018-04-24 19:03:26 UTC; 28s ago
   CGroup: /
           ├─user.slice
```

After:
```
debian@beaglebone:~$ systemctl status
● beaglebone
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Tue 2018-04-24 19:01:35 UTC; 29s ago
   CGroup: /
           ├─user.slice
```

Regards,