### PR TITLE
Fix for rc_test_motors doesn't run all motors

### DIFF
--- a/examples/src/rc_test_motors.c
+++ b/examples/src/rc_test_motors.c
@@ -62,8 +62,8 @@ int main(int argc, char *argv[])
 			if(in<=4 && in>=1){
 				ch = in;
 			}
-			else{
-				printf("motor option must be from 1-4\n");
+			else if(ch != 0) {
++				printf("motor option must be from 1-4, or 0 for all\n");
 				return -1;
 			}
 			break;


### PR DESCRIPTION
From the help output, not supplying a motor number should run all motors. However, the test previously insisted on a motor number being supplied even though the default was to run all numbers.
From reading the library, I *think* this should work but I'm not 100% sure. Don't have machine at hand to test on right at the moment. And my C is a little ancient, too....